### PR TITLE
feat: add release workflow with GitHub Release + GHCR Docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Run tests
+        run: make test-unit
+
+      - name: Build linux/amd64
+        env:
+          CGO_ENABLED: '0'
+          GOOS: linux
+          GOARCH: amd64
+        run: |
+          go build -o dora-exporter-linux-amd64 cmd/main.go
+
+      - name: Build linux/arm64
+        env:
+          CGO_ENABLED: '0'
+          GOOS: linux
+          GOARCH: arm64
+        run: |
+          go build -o dora-exporter-linux-arm64 cmd/main.go
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            dora-exporter-linux-amd64
+            dora-exporter-linux-arm64
+            configs/config.yml.dist
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version tag
+        id: meta
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/mprokopov/dora-exporter:${{ steps.meta.outputs.version }}
+            ghcr.io/mprokopov/dora-exporter:latest


### PR DESCRIPTION
Closes #3

### What
- GitHub Actions workflow that triggers on tag push (`v*.*.*`)
- Builds Go binaries for `linux/amd64` and `linux/arm64`
- Creates a GitHub Release with binaries + sample config attached
- Builds multi-arch Docker image and pushes to `ghcr.io/mprokopov/dora-exporter`

### Usage
After merge, create a release:
```bash
git tag v1.0.0
git push origin v1.0.0
```

This will automatically create a GitHub Release and push the Docker image.