### PR TITLE
Hardening: snapshot writes, error handling, logging, idioms, toolchain, Docker & CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.gitignore
+.idea
+.DS_Store
+*.log
+tmp/
+dashboards/
+images/
+README.md
+LICENSE
+*.prom
+dora-exporter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify gofmt
+        run: |
+          unformatted="$(gofmt -l cmd pkg)"
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt-formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: Run tests (race)
+        run: go test -race ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,16 @@
+# golangci-lint configuration
+# https://golangci-lint.run/usage/configuration/
+
+linters-settings:
+  errcheck:
+    # go-kit's Logger.Log returns an error that is conventionally ignored
+    # (fire-and-forget logging). Excluding it keeps errcheck meaningful for
+    # real error returns (file/JSON/HTTP operations) without the noise.
+    exclude-functions:
+      - (github.com/go-kit/log.Logger).Log
+
+issues:
+  # Report every occurrence rather than capping repeated findings, so CI
+  # surfaces the full picture.
+  max-same-issues: 0
+  max-issues-per-linter: 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,28 @@
-FROM golang:1.19.2 as builder
-WORKDIR /usr/local/go/src/dora-exporter
-COPY go.mod ./
-COPY go.sum ./
+FROM golang:1.24-alpine AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
 COPY Makefile ./
 COPY pkg/ pkg/
 COPY cmd/ cmd/
-RUN make deps
 RUN make dist
 
-FROM alpine:3.16.2
-MAINTAINER Maksym Prokopov <mprokopov@gmaio.com>
-COPY --from=builder /usr/local/go/src/dora-exporter/dora-exporter .
+FROM alpine:3.21
+LABEL org.opencontainers.image.authors="Maksym Prokopov <mprokopov@gmail.com>"
+LABEL org.opencontainers.image.source="https://github.com/mprokopov/dora-exporter"
+
+RUN apk add --no-cache wget \
+    && addgroup -S dora && adduser -S -G dora dora
+
+WORKDIR /app
+COPY --from=builder /src/dora-exporter .
 COPY configs/config.yml.dist config.yml
 
+USER dora
+
 EXPOSE 8090
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD wget -qO- http://localhost:8090/metrics >/dev/null 2>&1 || exit 1
 
 ENTRYPOINT ["./dora-exporter"]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -71,7 +71,6 @@ func main() {
 	}
 
 	github.SetCatalog(cat)
-	jira.SetCatalog(cat)
 
 	exp = prom.NewExporter()
 	prom.SetExporter(exp)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,15 +51,23 @@ func HandlerWithSave(file string, handler func(w http.ResponseWriter, r *http.Re
 }
 
 func main() {
-	conf.Load(configFile)
+	if err := conf.Load(configFile); err != nil {
+		level.Error(logger).Log("config", "load", "file", configFile, "error", err)
+		os.Exit(1)
+	}
 	fileName = conf.Storage.File.Path
 
 	github.SetGitHubApi(conf.Github)
 
+	var catErr error
 	if conf.Catalog.Mode == "backstage" {
-		cat = catalog.NewCatalogFromBackstage(conf.Catalog.Endpoint, conf.Catalog.Token)
+		cat, catErr = catalog.NewCatalogFromBackstage(conf.Catalog.Endpoint, conf.Catalog.Token)
 	} else {
-		cat = catalog.NewCatalogFromYaml(conf.GetTeamsString())
+		cat, catErr = catalog.NewCatalogFromYaml(conf.GetTeamsString())
+	}
+	if catErr != nil {
+		level.Error(logger).Log("catalog", "init", "mode", conf.Catalog.Mode, "error", catErr)
+		os.Exit(1)
 	}
 
 	github.SetCatalog(cat)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mprokopov/dora-exporter
 
-go 1.18
+go 1.24
 
 require (
 	github.com/go-kit/log v0.2.1

--- a/pkg/dora-exporter/catalog/backstage_test.go
+++ b/pkg/dora-exporter/catalog/backstage_test.go
@@ -28,7 +28,10 @@ func TestBackstageCatalogPreservesBasePath(t *testing.T) {
 	}))
 	defer server.Close()
 
-	service := catalog.NewCatalogFromBackstage(server.URL+"/backstage", "")
+	service, err := catalog.NewCatalogFromBackstage(server.URL+"/backstage", "")
+	if err != nil {
+		t.Fatalf("new backstage catalog: %v", err)
+	}
 	if got := service.GetTeamNameByRepository("mprokopov/dora-exporter"); got != "Platform" {
 		t.Fatalf("team = %q, want Platform", got)
 	}

--- a/pkg/dora-exporter/catalog/catalog.go
+++ b/pkg/dora-exporter/catalog/catalog.go
@@ -71,27 +71,27 @@ func (teams Teams) GetTeamNameByProject(project string) string {
 	return "Unknown"
 }
 
-func NewCatalogFromYaml(yamlString string) TeamsCatalog {
+func NewCatalogFromYaml(yamlString string) (TeamsCatalog, error) {
 	var teams Teams
 	err := yaml.Unmarshal([]byte(yamlString), &teams)
 	if err != nil {
-		level.Error(logger).Log(err)
-		panic(1)
+		level.Error(logger).Log("catalog", "static", "error", err)
+		return nil, err
 	}
 	level.Info(logger).Log("catalog", "static", "teams", len(teams))
-	return teams
+	return teams, nil
 }
 
-func NewCatalogFromBackstage(backstageUrl string, token string) TeamsCatalog {
+func NewCatalogFromBackstage(backstageUrl string, token string) (TeamsCatalog, error) {
 	url, err := url.Parse(backstageUrl)
 	if err != nil {
-		level.Error(logger).Log(err)
-		panic(1)
+		level.Error(logger).Log("catalog", "backstage", "error", err)
+		return nil, err
 	}
 
 	var backstage = BackstageCatalog{Endpoint: *url, Token: token}
 	level.Info(logger).Log("catalog", "backstage", "endpoint", url.String())
-	return backstage
+	return backstage, nil
 }
 
 // GET :base-url/:base-path/entities?filter=metadata.annotations.github.com/project-slug=mprokopov/dora-exporter
@@ -139,7 +139,7 @@ func (backstage BackstageCatalog) Fetch(filter string) ([]byte, error) {
 
 	req, err := http.NewRequest(http.MethodGet, uri.String(), http.NoBody)
 	if err != nil {
-		level.Error(logger).Log("catalog", err)
+		level.Error(logger).Log("catalog", "request", "error", err)
 		return nil, err
 	}
 
@@ -150,7 +150,7 @@ func (backstage BackstageCatalog) Fetch(filter string) ([]byte, error) {
 	client := http.Client{Timeout: 15 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		level.Error(logger).Log("catalog", err)
+		level.Error(logger).Log("catalog", "fetch", "error", err)
 		return nil, err
 	}
 	defer resp.Body.Close()

--- a/pkg/dora-exporter/catalog/catalog.go
+++ b/pkg/dora-exporter/catalog/catalog.go
@@ -19,7 +19,6 @@ var logger log.Logger
 
 func SetLogger(log log.Logger) {
 	logger = log
-	return
 }
 
 type Team struct {
@@ -128,8 +127,7 @@ func (backstage BackstageCatalog) GetTeamNameByProject(project string) string {
 }
 
 func (backstage BackstageCatalog) Fetch(filter string) ([]byte, error) {
-	var uri url.URL
-	uri = backstage.Endpoint
+	uri := backstage.Endpoint
 	uri.Path = strings.TrimRight(uri.Path, "/") + "/api/catalog/entities"
 	q := uri.Query()
 

--- a/pkg/dora-exporter/catalog/catalog_test.go
+++ b/pkg/dora-exporter/catalog/catalog_test.go
@@ -36,7 +36,11 @@ var logger = log.NewLogfmtLogger(os.Stdout)
 
 func SetupCatalog() catalog.TeamsCatalog {
 	catalog.SetLogger(logger)
-	return catalog.NewCatalogFromYaml(example)
+	service, err := catalog.NewCatalogFromYaml(example)
+	if err != nil {
+		panic(err)
+	}
+	return service
 }
 
 func TestGetCatalogByRepository(t *testing.T) {
@@ -45,7 +49,7 @@ func TestGetCatalogByRepository(t *testing.T) {
 	examples := map[string]string{
 		"mprokopov/provisioner": "Infra",
 		"mprokopov/alfred":      "Risk",
-		"not_found":           "Unknown"}
+		"not_found":             "Unknown"}
 
 	for repo, want := range examples {
 		got := service.GetTeamNameByRepository(repo)

--- a/pkg/dora-exporter/config/config.go
+++ b/pkg/dora-exporter/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 
 	"errors"
@@ -46,30 +45,32 @@ func SetLogger(log log.Logger) {
 	return
 }
 
-func NewConfigFromFile(file string) *Config {
+func NewConfigFromFile(file string) (*Config, error) {
 	conf := &Config{}
-	conf.Load(file)
-	return conf
+	if err := conf.Load(file); err != nil {
+		return nil, err
+	}
+	return conf, nil
 }
 
-func (c *Config) Load(file string) *Config {
-	yamlFile, err := ioutil.ReadFile(file)
+func (c *Config) Load(file string) error {
+	yamlFile, err := os.ReadFile(file)
 
 	if err != nil {
 		level.Error(logger).Log("config", file, "error", err)
-		os.Exit(1)
+		return err
 	}
 
 	err = yaml.Unmarshal(yamlFile, c)
 	if err != nil {
 		level.Error(logger).Log("config", file, "error", err)
-		os.Exit(1)
+		return err
 	}
 	if c.Github.Token == "" {
 		if os.Getenv("GITHUB_TOKEN") == "" {
-			err := errors.New("No GitHub token found")
+			err := errors.New("no GitHub token found")
 			level.Error(logger).Log("config", file, "github_token", err)
-			os.Exit(1)
+			return err
 		}
 		c.Github.Token = os.Getenv("GITHUB_TOKEN")
 	}
@@ -97,7 +98,7 @@ func (c *Config) Load(file string) *Config {
 	}
 
 	level.Info(logger).Log("config", "finished", "file", file)
-	return c
+	return nil
 }
 
 func (c *Config) GetTeams() catalog.Teams {

--- a/pkg/dora-exporter/config/config.go
+++ b/pkg/dora-exporter/config/config.go
@@ -42,7 +42,6 @@ var logger log.Logger
 
 func SetLogger(log log.Logger) {
 	logger = log
-	return
 }
 
 func NewConfigFromFile(file string) (*Config, error) {

--- a/pkg/dora-exporter/config/config_test.go
+++ b/pkg/dora-exporter/config/config_test.go
@@ -16,7 +16,10 @@ func TestNewConfigFromFileAllocatesConfig(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	conf := NewConfigFromFile(path)
+	conf, err := NewConfigFromFile(path)
+	if err != nil {
+		t.Fatalf("new config: %v", err)
+	}
 	if conf == nil {
 		t.Fatal("config is nil")
 	}

--- a/pkg/dora-exporter/github/api.go
+++ b/pkg/dora-exporter/github/api.go
@@ -54,7 +54,7 @@ func (api GithubApi) Fetch(path string) ([]byte, error) {
 
 	req, err := http.NewRequest(http.MethodGet, url.String(), http.NoBody)
 	if err != nil {
-		level.Error(logger).Log(err)
+		level.Error(logger).Log("component", "github_api", "error", err)
 		return nil, err
 	}
 	req.Header.Add("Authorization", "token "+api.Token)
@@ -66,7 +66,7 @@ func (api GithubApi) Fetch(path string) ([]byte, error) {
 	level.Debug(logger).Log("component", "github_api", "call", url.String())
 
 	if err != nil {
-		level.Error(logger).Log(err)
+		level.Error(logger).Log("component", "github_api", "error", err)
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -102,13 +102,13 @@ func (api GithubApi) PullRequestInfo(repo string, pullRequestNumber string) []Pu
 	var pullRequests []PullRequest
 	resBody, err := api.Fetch(fmt.Sprintf("/repos/%s/%s/pulls/%s/commits", api.Owner, repo, pullRequestNumber))
 	if err != nil {
-		level.Error(logger).Log(err)
+		level.Error(logger).Log("component", "github_api", "error", err)
 		return pullRequests
 	}
 
 	err = json.Unmarshal(resBody, &pullRequests)
 	if err != nil {
-		level.Error(logger).Log(err)
+		level.Error(logger).Log("component", "github_api", "error", err)
 		return nil
 	}
 
@@ -122,13 +122,13 @@ func (api GithubApi) CommitInfo(repo string, sha string) Commit {
 	var commit Commit
 	resBody, err := api.Fetch(fmt.Sprintf("/repos/%s/%s/git/commits/%s", api.Owner, repo, sha))
 	if err != nil {
-		level.Error(logger).Log(err)
+		level.Error(logger).Log("component", "github_api", "error", err)
 		return commit
 	}
 
 	err = json.Unmarshal(resBody, &commit)
 	if err != nil {
-		level.Error(logger).Log(err)
+		level.Error(logger).Log("component", "github_api", "error", err)
 	}
 
 	level.Debug(logger).Log("component", "github_api", "repo", repo, "commit_info", sha)

--- a/pkg/dora-exporter/github/api.go
+++ b/pkg/dora-exporter/github/api.go
@@ -19,7 +19,6 @@ var logger log.Logger
 
 func SetLogger(log log.Logger) {
 	logger = log
-	return
 }
 
 type GithubApi struct {

--- a/pkg/dora-exporter/github/github.go
+++ b/pkg/dora-exporter/github/github.go
@@ -17,13 +17,13 @@ type Deployment_Status struct {
 }
 
 type Deployment struct {
-	Url             string
-	Id              int
-	Ref             string
-	Sha             string
-	Environment     string
-	Payload         struct {
-	    Redeployment string
+	Url         string
+	Id          int
+	Ref         string
+	Sha         string
+	Environment string
+	Payload     struct {
+		Redeployment string
 	}
 }
 
@@ -45,13 +45,6 @@ type GitHubWebhookPayload struct {
 	Deployment        Deployment
 	Repository        Repository
 	Sender            Sender
-}
-
-var teams catalog.Teams
-
-func SetTeams(t catalog.Teams) {
-	teams = t
-	return
 }
 
 var cat catalog.TeamsCatalog
@@ -89,10 +82,10 @@ func GithubAPIHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	labels := prometheus.Labels{
-		"repo":        payload.Repository.Name,
-		"environment": payload.Deployment.Environment,
-		"team":        cat.GetTeamNameByRepository(payload.Repository.Full_Name),
-		"status":      payload.Deployment_Status.State,
+		"repo":         payload.Repository.Name,
+		"environment":  payload.Deployment.Environment,
+		"team":         cat.GetTeamNameByRepository(payload.Repository.Full_Name),
+		"status":       payload.Deployment_Status.State,
 		"redeployment": payload.Deployment.Payload.Redeployment,
 	}
 

--- a/pkg/dora-exporter/jira/jira.go
+++ b/pkg/dora-exporter/jira/jira.go
@@ -79,26 +79,26 @@ type JiraPayload struct {
 	Issue Issue
 }
 
-func ExtractIssue(body io.ReadCloser) (error, Issue) {
+func ExtractIssue(body io.ReadCloser) (Issue, error) {
 	var payload JiraPayload
 
 	decoder := json.NewDecoder(body)
 	err := decoder.Decode(&payload)
 
 	if err != nil {
-		return err, Issue{}
+		return Issue{}, err
 	}
 
 	level.Info(logger).Log(
 		"event", payload.Event,
 	)
 
-	return nil, payload.Issue
+	return payload.Issue, nil
 }
 
 func JiraNewTicketHandler(w http.ResponseWriter, r *http.Request) {
 	var labels prometheus.Labels
-	err, issue := ExtractIssue(r.Body)
+	issue, err := ExtractIssue(r.Body)
 
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -124,7 +124,7 @@ func JiraNewTicketHandler(w http.ResponseWriter, r *http.Request) {
 
 func JiraClosedTicketHandler(w http.ResponseWriter, r *http.Request) {
 	var labels prometheus.Labels
-	err, issue := ExtractIssue(r.Body)
+	issue, err := ExtractIssue(r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -146,10 +146,9 @@ func JiraClosedTicketHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func JiraIncidentHandler(w http.ResponseWriter, r *http.Request) {
-	var issue Issue
 	var labels prometheus.Labels
 
-	err, issue := ExtractIssue(r.Body)
+	issue, err := ExtractIssue(r.Body)
 
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/pkg/dora-exporter/jira/jira.go
+++ b/pkg/dora-exporter/jira/jira.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-kit/log/level"
 
 	"github.com/go-kit/log"
-	"github.com/mprokopov/dora-exporter/pkg/dora-exporter/catalog"
 	prom "github.com/mprokopov/dora-exporter/pkg/dora-exporter/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -18,14 +17,6 @@ var logger log.Logger
 
 func SetLogger(log log.Logger) {
 	logger = log
-	return
-}
-
-var cat catalog.TeamsCatalog
-
-func SetCatalog(catalog catalog.TeamsCatalog) {
-	cat = catalog
-	level.Info(logger).Log("jira", "catalog service set")
 }
 
 // GetDuration returns time difference since time.now and issue.Fields.Created in seconds

--- a/pkg/dora-exporter/prometheus/prometheus.go
+++ b/pkg/dora-exporter/prometheus/prometheus.go
@@ -26,7 +26,6 @@ var logger log.Logger
 
 func SetLogger(log log.Logger) {
 	logger = log
-	return
 }
 
 var exp *Exporter

--- a/pkg/dora-exporter/prometheus/prometheus.go
+++ b/pkg/dora-exporter/prometheus/prometheus.go
@@ -31,6 +31,11 @@ func SetLogger(log log.Logger) {
 
 var exp *Exporter
 
+// saveMu serializes snapshot writes so concurrent webhook handlers cannot
+// race on the same file. WriteToTextfile renames a temp file into place, so
+// combined with this lock the on-disk snapshot is never partially written.
+var saveMu sync.Mutex
+
 func SetExporter(e *Exporter) {
 	exp = e
 }
@@ -159,6 +164,9 @@ func (e *Exporter) Update(family string, metric *io_prometheus_client.Metric) {
 }
 
 func SaveMetricsToFile(file string) error {
+	saveMu.Lock()
+	defer saveMu.Unlock()
+
 	if err := prometheus.WriteToTextfile(file, prometheus.DefaultGatherer); err != nil {
 		_ = level.Error(logger).Log("metrics", "export_failed", "file", file, "error", err)
 		return err


### PR DESCRIPTION
Closes #13.

A batch of correctness, robustness, and tooling improvements from the codebase review.

### Changes

**#2 — Serialize snapshot writes**
`SaveMetricsToFile` is now guarded by a mutex so concurrent webhook handlers can't race on the snapshot file. Combined with `WriteToTextfile`'s atomic rename, the on-disk file is never partially written.

**#3 — Remove `os.Exit`/`panic` from library packages**
`config.Load` / `NewConfigFromFile` and both `NewCatalogFrom*` constructors now return errors instead of terminating the process. `main` decides when to exit. Makes the packages testable and reusable.

**#4 — Fix malformed go-kit log calls**
Several sites called `level.Error(logger).Log(err)` with a single argument; go-kit expects key/value pairs, producing broken logfmt. Now `Log("error", err)`.

**#10 — Dead code & idioms**
- Removed unused `github.SetTeams` + `teams` var.
- `jira.ExtractIssue` now returns `(Issue, error)` (error last).
- Dropped the shadowed `issue` variable in `JiraIncidentHandler`.

**#12 — Toolchain**
`go.mod` bumped 1.18 → 1.24; replaced deprecated `io/ioutil` with `os`.

**#13 — Dockerfile hygiene**
Dropped deprecated `MAINTAINER` (and fixed the `gmaio.com` typo) for OCI `LABEL`s, refreshed base images (`golang:1.24-alpine`, `alpine:3.21`), runs as a non-root `dora` user, added a `HEALTHCHECK`, and added `.dockerignore`.

**#11 — CI workflow**
New `.github/workflows/ci.yml` running on pushes to `main` and on PRs: gofmt check, `go vet`, `go test -race`, and `golangci-lint`. Go version is sourced from `go.mod`.

### Verification
- `go vet ./...` — clean
- `go build` — OK
- `go test -race ./...` — all packages pass
- `gofmt` — clean
- Tests updated for the new error-returning signatures

Docker image build was validated by inspection (no daemon available in the dev environment); the build stage mirrors the original `make dist` flow.

Not included (left for follow-ups): #1 webhook signature verification.

https://claude.ai/code/session_01Ve464mvbXe4HpBHyJyor1Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ve464mvbXe4HpBHyJyor1Q)_